### PR TITLE
Created unit test for link

### DIFF
--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="CompilerConfiguration">
-    <bytecodeTargetLevel target="11" />
+    <bytecodeTargetLevel target="17" />
   </component>
 </project>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,7 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ExternalStorageConfigurationManager" enabled="true" />
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_11" default="true" project-jdk-name="temurin-11" project-jdk-type="JavaSDK">
+  <component name="FrameworkDetectionExcludesConfiguration">
+    <file type="web" url="file://$PROJECT_DIR$" />
+  </component>
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_17" project-jdk-name="17" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/out" />
   </component>
 </project>

--- a/src/test/java/org/tealeaf/javamarkdown/inline/ImageTest.java
+++ b/src/test/java/org/tealeaf/javamarkdown/inline/ImageTest.java
@@ -1,0 +1,6 @@
+package org.tealeaf.javamarkdown.inline;
+
+public class ImageTest {
+
+
+}

--- a/src/test/java/org/tealeaf/javamarkdown/inline/ImageTest.java
+++ b/src/test/java/org/tealeaf/javamarkdown/inline/ImageTest.java
@@ -1,6 +1,20 @@
 package org.tealeaf.javamarkdown.inline;
 
+import org.junit.jupiter.api.Test;
+import org.tealeaf.javamarkdown.IllegalContentsException;
+import static org.junit.jupiter.api.Assertions.*;
+
+
 public class ImageTest {
 
+    @Test
+    void testAsString() throws IllegalContentsException {
+        String src = "https://avatars.githubusercontent.com/u/35083315?v=4";
+        Image image = new Image(src);
 
-}
+        assertFalse(src.isEmpty());
+        assertEquals("![]("+src+")", image.asString());
+
+    }
+
+    }

--- a/src/test/java/org/tealeaf/javamarkdown/inline/LinkTest.java
+++ b/src/test/java/org/tealeaf/javamarkdown/inline/LinkTest.java
@@ -1,0 +1,30 @@
+package org.tealeaf.javamarkdown.inline;
+import org.junit.jupiter.api.Test;
+import org.tealeaf.javamarkdown.IllegalContentsException;
+import java.io.IOException;
+import java.io.StringWriter;
+import static org.junit.jupiter.api.Assertions.*;
+
+public class LinkTest {
+    static String url = "https://www.goodreads.com/";
+    static String content = "Books";
+    @Test
+    void testToWriter() throws IllegalContentsException, IOException{
+
+       Link link = new Link(content,url);
+       StringWriter writer = new StringWriter();
+       assertEquals( "["+content+"]" + "("+url+")" ,link.toWriter(writer).toString());
+    }
+
+    @Test
+    void testAsString(){
+        Link link = new Link(content,url);
+        assertTrue(link.asString().contains(content));
+        assertTrue(link.asString().contains(url));
+        assertEquals("["+content+"]" + "("+url+")", link.asString());
+        assertEquals('[', link.asString().charAt(0));
+        assertEquals(')', link.asString().charAt(link.asString().length() - 1));
+    }
+
+
+}


### PR DESCRIPTION
Added test for list as requested in [#58](https://github.com/LittleTealeaf/JavaMarkdown/issues/58)
And image #57 

>But i noticed that on #57 there could be an improvement on the production code. See below

```java
public class Image extends Link {
    public Image(String src) {
        super("", src);
    }

    @Override
    public String asString() {
        return String.format("!%s", super.asString());
    }
}
```

The content parameter on the image constructor shouldn't be an empty string. As markdown also support `alt text` as shown [here](https://github.com/adam-p/markdown-here/wiki/Markdown-Cheatsheet#images). 
My suggestion is that the image also contains a content as the link does.