### PR TITLE
Removed unnecessary toWriter methods

### DIFF
--- a/src/main/java/org/tealeaf/javamarkdown/elements/Header.java
+++ b/src/main/java/org/tealeaf/javamarkdown/elements/Header.java
@@ -3,9 +3,6 @@ package org.tealeaf.javamarkdown.elements;
 import org.tealeaf.javamarkdown.exceptions.IllegalHeaderLevelException;
 import org.tealeaf.javamarkdown.types.Structure;
 
-import java.io.IOException;
-import java.io.Writer;
-
 /**
  * <p>Represents a header in a markdown document. This will render the content in a large font, depending on the header size</p>
  *
@@ -43,10 +40,10 @@ public class Header extends Structure {
         this.content = checkType(content);
     }
 
-    @Override
-    public Writer toWriter(Writer writer) throws IOException {
-        return writer.append("#".repeat(level).concat(" ").concat(content.toString()));
-    }
+    // @Override
+    // public Writer toWriter(Writer writer) throws IOException {
+    //     return writer.append("#".repeat(level).concat(" ").concat(content.toString()));
+    // }
 
     @Override
     public String asString() {

--- a/src/main/java/org/tealeaf/javamarkdown/elements/Link.java
+++ b/src/main/java/org/tealeaf/javamarkdown/elements/Link.java
@@ -2,9 +2,6 @@ package org.tealeaf.javamarkdown.elements;
 
 import org.tealeaf.javamarkdown.types.InlineElement;
 
-import java.io.IOException;
-import java.io.Writer;
-
 public class Link extends InlineElement {
 
     private final Object content;
@@ -14,11 +11,6 @@ public class Link extends InlineElement {
         checkType(content);
         this.content = content;
         this.url = url;
-    }
-
-    @Override
-    public Writer toWriter(Writer writer) throws IOException {
-        return writer.append(asString());
     }
 
     @Override

--- a/src/main/java/org/tealeaf/javamarkdown/types/ListStructure.java
+++ b/src/main/java/org/tealeaf/javamarkdown/types/ListStructure.java
@@ -2,8 +2,6 @@ package org.tealeaf.javamarkdown.types;
 
 import org.tealeaf.javamarkdown.exceptions.IllegalContentsException;
 
-import java.io.IOException;
-import java.io.Writer;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -103,14 +101,6 @@ public abstract class ListStructure extends Structure {
         } else {
             return list;
         }
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public Writer toWriter(Writer writer) throws IOException {
-        return writer.append(asString());
     }
 
     /**

--- a/src/main/java/org/tealeaf/javamarkdown/types/Markup.java
+++ b/src/main/java/org/tealeaf/javamarkdown/types/Markup.java
@@ -1,10 +1,5 @@
 package org.tealeaf.javamarkdown.types;
 
-import org.tealeaf.javamarkdown.MarkdownElement;
-
-import java.io.IOException;
-import java.io.Writer;
-
 /**
  * Represents markdown elements that indicates a simple markup syntax to the content text, such as {@code **words**} to indicate <b>bold</b> text.
  * @author Thomas Kwashnak
@@ -52,14 +47,14 @@ public class Markup extends InlineElement {
     }
 
 
-    @Override
-    public Writer toWriter(Writer writer) throws IOException {
-        if(object instanceof MarkdownElement) {
-            return ((MarkdownElement) object).toWriter(writer.append(syntax)).append(syntax);
-        } else {
-            return writer.append(syntax).append(object.toString()).append(syntax);
-        }
-    }
+    // @Override
+    // public Writer toWriter(Writer writer) throws IOException {
+    //     if(object instanceof MarkdownElement) {
+    //         return ((MarkdownElement) object).toWriter(writer.append(syntax)).append(syntax);
+    //     } else {
+    //         return writer.append(syntax).append(object.toString()).append(syntax);
+    //     }
+    // }
 
     @Override
     public String asString() {


### PR DESCRIPTION
With prior change to include a default toWriter method in `MarkdownElement`, many of the implemented versions of `toWriter` in various elements could be removed and just defaulted to the version defined in `MarkdownElement`