### PR TITLE
Simplified InlineElement checkType

### DIFF
--- a/src/main/java/org/tealeaf/javamarkdown/elements/Bold.java
+++ b/src/main/java/org/tealeaf/javamarkdown/elements/Bold.java
@@ -21,16 +21,5 @@ public class Bold extends Markup {
         super(content, MARKUP);
     }
 
-    /**
-     * {@inheritDoc}
-     * <pre>Throws {@link IllegalContentsException} if object is an instance of the {@link Bold} class</pre>
-     */
-    @Override
-    protected <T> T checkType(T object) throws IllegalContentsException {
-        if(object instanceof Bold) {
-            throw new IllegalContentsException(Bold.class);
-        } else {
-            return super.checkType(object);
-        }
-    }
+
 }

--- a/src/main/java/org/tealeaf/javamarkdown/elements/Code.java
+++ b/src/main/java/org/tealeaf/javamarkdown/elements/Code.java
@@ -13,7 +13,7 @@ public class Code extends Markup {
     @Override
     protected <T> T checkType(T object) {
         if(object instanceof MarkdownElement) {
-            throw new IllegalContentsException(MarkdownElement.class);
+            throw new IllegalContentsException(object.getClass());
         } else {
             return super.checkType(object);
         }

--- a/src/main/java/org/tealeaf/javamarkdown/elements/Italic.java
+++ b/src/main/java/org/tealeaf/javamarkdown/elements/Italic.java
@@ -9,12 +9,4 @@ public class Italic extends Markup {
         super(object, "*");
     }
 
-    @Override
-    protected <T> T checkType(T object)  {
-        if(object instanceof Italic) {
-            throw new IllegalContentsException(Italic.class);
-        } else {
-            return super.checkType(object);
-        }
-    }
 }

--- a/src/main/java/org/tealeaf/javamarkdown/elements/Strikethrough.java
+++ b/src/main/java/org/tealeaf/javamarkdown/elements/Strikethrough.java
@@ -9,12 +9,4 @@ public class Strikethrough extends Markup {
         super(object, "~~");
     }
 
-    @Override
-    protected <T> T checkType(T object) {
-        if(object instanceof Strikethrough) {
-            throw new IllegalContentsException(Strikethrough.class);
-        } else {
-            return super.checkType(object);
-        }
-    }
 }

--- a/src/main/java/org/tealeaf/javamarkdown/types/InlineElement.java
+++ b/src/main/java/org/tealeaf/javamarkdown/types/InlineElement.java
@@ -8,12 +8,14 @@ public abstract class InlineElement extends MarkdownElement {
     /**
      * {@inheritDoc}
      * <pre>Throws {@link IllegalContentsException} if object is an instance of the {@link Structure} class</pre>
+     * <pre>Throws {@link IllegalContentsException} if object is an instance of the child class of {@link InlineElement}</pre>
      */
     @Override
     protected <T> T checkType(T object) {
-        if (object instanceof Structure) {
-            throw new IllegalContentsException(Structure.class);
+        if (object instanceof Structure || getClass().isInstance(object)) {
+            throw new IllegalContentsException(object.getClass());
         } else {
+
             return object;
         }
     }


### PR DESCRIPTION
Now, individual inline elements do not have to declare not allowing objects of the same type being illegal